### PR TITLE
support  custom "alwayson_scripts"

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: set up JDK 11
+    - name: set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: gradle
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,26 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/app/src/main/java/com/jsoft/diffusionpaint/dto/SdParam.java
+++ b/app/src/main/java/com/jsoft/diffusionpaint/dto/SdParam.java
@@ -12,6 +12,7 @@ public class SdParam {
     public int inpaintPartial = 0;
     public int sdSize;
     public String model;
+    public String asapi = "{}";
 
     public List<CnParam> cn;
     public static final String SD_MODEL_V1 = "v1Model";

--- a/app/src/main/java/com/jsoft/diffusionpaint/helper/SdApiHelper.java
+++ b/app/src/main/java/com/jsoft/diffusionpaint/helper/SdApiHelper.java
@@ -418,6 +418,9 @@ public class SdApiHelper {
             jsonObject.put("save_images", false);
             jsonObject.put("denoising_strength", param.denoise);
             jsonObject.put("cfg_scale", param.cfgScale);
+            if (sdParam.asapi != null) {
+                jsonObject.put("alwayson_scripts", new JSONObject(sdParam.asapi));
+            }
 
             // ControlNet Args
             if (param.cn != null) {
@@ -466,6 +469,9 @@ public class SdApiHelper {
                     }
                 }
                 controlnet.put("args", args);
+                if (sdParam.asapi != null) {
+                    alwayson_scripts = new JSONObject(jsonObject.getJSONObject("alwayson_scripts").toString());
+                }
                 alwayson_scripts.put("controlnet", controlnet);
                 jsonObject.put("alwayson_scripts", alwayson_scripts);
             }

--- a/app/src/main/java/com/jsoft/diffusionpaint/helper/SdApiHelper.java
+++ b/app/src/main/java/com/jsoft/diffusionpaint/helper/SdApiHelper.java
@@ -271,8 +271,8 @@ public class SdApiHelper {
             jsonObject.put("negative_prompt", sharedPreferences.getString("negativePrompt", "") + ", " + mCurrentSketch.getNegPrompt());
             jsonObject.put("sampler_name", sharedPreferences.getString("sdSampler", "Euler a"));
             jsonObject.put("save_images", false);
-            if (sdParam.asapi != null) {
-                jsonObject.put("alwayson_scripts", new JSONObject(sdParam.asapi));
+            if (param.asapi != null) {
+                jsonObject.put("alwayson_scripts", new JSONObject(param.asapi));
             }
 
             if (param.cn != null) {
@@ -308,7 +308,7 @@ public class SdApiHelper {
                     }
                 }
                 controlnet.put("args", args);
-                if (sdParam.asapi != null) {
+                if (param.asapi != null) {
                     alwayson_scripts = new JSONObject(jsonObject.getJSONObject("alwayson_scripts").toString());
                 }
                 alwayson_scripts.put("controlnet", controlnet);
@@ -418,8 +418,8 @@ public class SdApiHelper {
             jsonObject.put("save_images", false);
             jsonObject.put("denoising_strength", param.denoise);
             jsonObject.put("cfg_scale", param.cfgScale);
-            if (sdParam.asapi != null) {
-                jsonObject.put("alwayson_scripts", new JSONObject(sdParam.asapi));
+            if (param.asapi != null) {
+                jsonObject.put("alwayson_scripts", new JSONObject(param.asapi));
             }
 
             // ControlNet Args
@@ -469,7 +469,7 @@ public class SdApiHelper {
                     }
                 }
                 controlnet.put("args", args);
-                if (sdParam.asapi != null) {
+                if (param.asapi != null) {
                     alwayson_scripts = new JSONObject(jsonObject.getJSONObject("alwayson_scripts").toString());
                 }
                 alwayson_scripts.put("controlnet", controlnet);

--- a/app/src/main/java/com/jsoft/diffusionpaint/helper/SdApiHelper.java
+++ b/app/src/main/java/com/jsoft/diffusionpaint/helper/SdApiHelper.java
@@ -271,6 +271,9 @@ public class SdApiHelper {
             jsonObject.put("negative_prompt", sharedPreferences.getString("negativePrompt", "") + ", " + mCurrentSketch.getNegPrompt());
             jsonObject.put("sampler_name", sharedPreferences.getString("sdSampler", "Euler a"));
             jsonObject.put("save_images", false);
+            if (sdParam.asapi != null) {
+                jsonObject.put("alwayson_scripts", new JSONObject(sdParam.asapi));
+            }
 
             if (param.cn != null) {
                 JSONObject alwayson_scripts = new JSONObject();
@@ -305,6 +308,9 @@ public class SdApiHelper {
                     }
                 }
                 controlnet.put("args", args);
+                if (sdParam.asapi != null) {
+                    alwayson_scripts = new JSONObject(jsonObject.getJSONObject("alwayson_scripts").toString());
+                }
                 alwayson_scripts.put("controlnet", controlnet);
                 jsonObject.put("alwayson_scripts", alwayson_scripts);
             }


### PR DESCRIPTION
#12
Add the asapi field in Custom Mode to add custom "alwayson_scripts" content (compatible with the original controlnet)
For example:
The simple API usage of the ADetailer plug-in is:
```
"alwayson_scripts": {
   "ADetailer": {
     true,
     true,
     "args": [
       {
         "ad_model": "face_yolov8n.pt"
       }
     ]
   }
}
```
Set the Custom Mode 8 content to
`{"type":"txt2img", "sdSize":768,"asapi":"{\"ADetailer\": {\"args\": [true,true,{\"ad_model\": \"face_yolov8n. pt\"}]}}"}`
It will take effect

PS:
Only custom modes take effect. Built-in txt2img, SDXL txt2img and Preset Modes do not take effect.
Because I don't know how to use Android Studio, Java syntax and interface design, I can only modify it simply like this.
I hope the author can design a special interface similar to “Prompt prefix” to store variables so that all presets can take effect.

The above content is translated using translation software